### PR TITLE
Added PHP tuneables

### DIFF
--- a/7.4-nginx/Dockerfile
+++ b/7.4-nginx/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex; \
       php7.4-protobuf \
       php7.4-xml \
       php7.4-xmlrpc \
+      php7.4-soap \
       php7.4-zip \
       php7.4-zstd \
       rcs \

--- a/7.4-nginx/README.md
+++ b/7.4-nginx/README.md
@@ -1,4 +1,4 @@
-# PHP-FPM 8.1
+# PHP-FPM 7.4
 
 ## SMTP Configuration
 
@@ -35,6 +35,66 @@
       <td>PM_STREAM</td>
       <td>Postmark Message Stream ID</td>
       <td><pre>null</pre></td>
+    </tr>
+      <tr>
+      <td>PHP_MAX_CONN</td>
+      <td>Maximum number of connections</td>
+      <td>35</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_VAR</td>
+      <td>max_input_vars</td>
+      <td>3000</td>
+    </tr>
+    <tr>
+      <td>PHP_MEMORY_LIMIT</td>
+      <td>memory_limit</td>
+      <td>192M</td>
+    </tr>
+    <tr>
+      <td>PHP_UPLOAD_SIZE</td>
+      <td>upload_max_filesize</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_TIME</td>
+      <td>max_input_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_EXEC_TIME</td>
+      <td>max_execution_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_TIMEZONE</td>
+      <td>date.timezone</td>
+      <td>UTC</td>
+    </tr>
+    <tr>
+      <td>PHP_POST_SIZE</td>
+      <td>post_max_size</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_OPCACHE</td>
+      <td>opcache.enable</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>PHP_ERROR_REPORTING</td>
+      <td>error_reporting</td>
+      <td>E_ALL & ~E_DEPRECATED & ~E_STRICT</td>
+    </tr>
+    <tr>
+      <td>PHP_DISPLAY_ERRORS</td>
+      <td>display_errors</td>
+      <td>Off</td>
+    </tr>
+    <tr>
+      <td>PHP_LOG_ERRORS</td>
+      <td>log_errors</td>
+      <td>On</td>
     </tr>
   </tbody>
 </table>

--- a/7.4-nginx/startup/60-php-config.sh
+++ b/7.4-nginx/startup/60-php-config.sh
@@ -47,3 +47,40 @@ if [ -z ${PHP_POST_SIZE} ]; then
 else
   sed -i "s/post_max_size = .*/post_max_size = $PHP_POST_SIZE/g" "${PHP_INI_PATH}php.ini"
 fi
+
+if [ -z ${PHP_DISPLAY_ERRORS} ]; then
+  echo >&2 "PHP_DISPLAY_ERRORS not set, skipping..."
+else
+  sed -i "s/display_errors = .*/display_errors = $PHP_DISPLAY_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_ERROR_REPORTING} ]; then
+  echo >&2 "PHP_ERROR_REPORTING not set, skipping..."
+else
+  # first, verify if error_reporting string is valid
+  php -r "error_reporting($PHP_ERROR_REPORTING);" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo >&2 "PHP_ERROR_REPORTING is not valid, skipping..."
+  fi
+  sed -i "s/error_reporting = .*/error_reporting = $PHP_ERROR_REPORTING/g" "${PHP_INI_PATH}php.ini"
+fi
+
+# add opcache.enable bool
+if [ -z ${PHP_OPCACHE_ENABLE} ]; then
+  echo >&2 "PHP_OPCACHE_ENABLE not set, skipping..."
+else
+  echo >&2 "PHP_OPCACHE_ENABLE set, enabling..."
+  # if the line opcache.enable= exists, replace it, or else add it
+  if grep -q "opcache.enable=" "${PHP_INI_CONF_PATH}10-opcache.ini"; then
+    sed -i "s/opcache.enable=.*/opcache.enable=$PHP_OPCACHE_ENABLE/g" "${PHP_INI_CONF_PATH}10-opcache.ini"
+  else
+    echo "opcache.enable=$PHP_OPCACHE_ENABLE" >> "${PHP_INI_CONF_PATH}10-opcache.ini"
+  fi
+fi
+
+# add log_errors bool
+if [ -z ${PHP_LOG_ERRORS} ]; then
+  echo >&2 "PHP_LOG_ERRORS not set, skipping..."
+else
+  sed -i "s/log_errors=.*/log_errors=$PHP_LOG_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi

--- a/8.0-nginx/Dockerfile
+++ b/8.0-nginx/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex; \
       php8.0-protobuf \
       php8.0-xml \
       php8.0-xmlrpc \
+      php8.0-soap \
       php8.0-zip \
       php8.0-zstd \
       rcs \

--- a/8.0-nginx/README.md
+++ b/8.0-nginx/README.md
@@ -1,4 +1,4 @@
-# PHP-FPM 8.1
+# PHP-FPM 8.0
 
 ## SMTP Configuration
 
@@ -35,6 +35,66 @@
       <td>PM_STREAM</td>
       <td>Postmark Message Stream ID</td>
       <td><pre>null</pre></td>
+    </tr>
+      <tr>
+      <td>PHP_MAX_CONN</td>
+      <td>Maximum number of connections</td>
+      <td>35</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_VAR</td>
+      <td>max_input_vars</td>
+      <td>3000</td>
+    </tr>
+    <tr>
+      <td>PHP_MEMORY_LIMIT</td>
+      <td>memory_limit</td>
+      <td>192M</td>
+    </tr>
+    <tr>
+      <td>PHP_UPLOAD_SIZE</td>
+      <td>upload_max_filesize</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_TIME</td>
+      <td>max_input_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_EXEC_TIME</td>
+      <td>max_execution_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_TIMEZONE</td>
+      <td>date.timezone</td>
+      <td>UTC</td>
+    </tr>
+    <tr>
+      <td>PHP_POST_SIZE</td>
+      <td>post_max_size</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_OPCACHE</td>
+      <td>opcache.enable</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>PHP_ERROR_REPORTING</td>
+      <td>error_reporting</td>
+      <td>E_ALL & ~E_DEPRECATED & ~E_STRICT</td>
+    </tr>
+    <tr>
+      <td>PHP_DISPLAY_ERRORS</td>
+      <td>display_errors</td>
+      <td>Off</td>
+    </tr>
+    <tr>
+      <td>PHP_LOG_ERRORS</td>
+      <td>log_errors</td>
+      <td>On</td>
     </tr>
   </tbody>
 </table>

--- a/8.0-nginx/startup/60-php-config.sh
+++ b/8.0-nginx/startup/60-php-config.sh
@@ -3,6 +3,8 @@
 echo >&2 "Setting PHP tunables..."
 
 PHP_INI_PATH=/etc/php/8.0/fpm/
+PHP_INI_CONF_PATH=/etc/php/8.1/fpm/conf.d/
+
 
 sed -i 's/^;\? \?cgi.fix_pathinfo=.*/cgi.fix_pathinfo=0/g' ${PHP_INI_PATH}php.ini
 
@@ -46,4 +48,47 @@ if [ -z ${PHP_POST_SIZE} ]; then
   echo >&2 "PHP_POST_SIZE not set, skipping..."
 else
   sed -i "s/post_max_size = .*/post_max_size = $PHP_POST_SIZE/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_DISPLAY_ERRORS} ]; then
+  echo >&2 "PHP_DISPLAY_ERRORS not set, skipping..."
+else
+  sed -i "s/display_errors = .*/display_errors = $PHP_DISPLAY_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_ERROR_REPORTING} ]; then
+  echo >&2 "PHP_ERROR_REPORTING not set, skipping..."
+else
+  # first, verify if error_reporting string is valid
+  php -r "error_reporting($PHP_ERROR_REPORTING);" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo >&2 "PHP_ERROR_REPORTING is not valid, skipping..."
+  fi
+  sed -i "s/error_reporting = .*/error_reporting = $PHP_ERROR_REPORTING/g" "${PHP_INI_PATH}php.ini"
+fi
+
+# add opcache.enable bool
+if [ -z ${PHP_OPCACHE_ENABLE} ]; then
+  echo >&2 "PHP_OPCACHE_ENABLE not set, skipping..."
+else
+  # if the line opcache.enable= exists, replace it, or else add it
+  if grep -q "opcache.enable=" "${PHP_INI_CONF_PATH}10-opcache.ini"; then
+    sed -i "s/opcache.enable=.*/opcache.enable=$PHP_OPCACHE_ENABLE/g" "${PHP_INI_CONF_PATH}10-opcache.ini"
+  else
+    echo "opcache.enable=$PHP_OPCACHE_ENABLE" >> "${PHP_INI_CONF_PATH}10-opcache.ini"
+  fi
+fi
+
+# add log_errors bool
+if [ -z ${PHP_LOG_ERRORS} ]; then
+  echo >&2 "PHP_LOG_ERRORS not set, skipping..."
+else
+  sed -i "s/log_errors=.*/log_errors=$PHP_LOG_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi
+
+# add file_uploads bool
+if [ -z ${PHP_FILE_UPLOADS} ]; then
+  echo >&2 "PHP_FILE_UPLOADS not set, skipping..."
+else
+  sed -i "s/file_uploads =.*/file_uploads = $PHP_FILE_UPLOADS/g" "${PHP_INI_PATH}php.ini"
 fi

--- a/8.0-nginx/startup/60-php-config.sh
+++ b/8.0-nginx/startup/60-php-config.sh
@@ -85,10 +85,3 @@ if [ -z ${PHP_LOG_ERRORS} ]; then
 else
   sed -i "s/log_errors=.*/log_errors=$PHP_LOG_ERRORS/g" "${PHP_INI_PATH}php.ini"
 fi
-
-# add file_uploads bool
-if [ -z ${PHP_FILE_UPLOADS} ]; then
-  echo >&2 "PHP_FILE_UPLOADS not set, skipping..."
-else
-  sed -i "s/file_uploads =.*/file_uploads = $PHP_FILE_UPLOADS/g" "${PHP_INI_PATH}php.ini"
-fi

--- a/8.1-nginx/Dockerfile
+++ b/8.1-nginx/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex; \
       php8.1-protobuf \
       php8.1-xml \
       php8.1-xmlrpc \
+      php8.1-soap \
       php8.1-zip \
       php8.1-zstd \
       rcs \

--- a/8.1-nginx/README.md
+++ b/8.1-nginx/README.md
@@ -36,6 +36,66 @@
       <td>Postmark Message Stream ID</td>
       <td><pre>null</pre></td>
     </tr>
+      <tr>
+      <td>PHP_MAX_CONN</td>
+      <td>Maximum number of connections</td>
+      <td>35</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_VAR</td>
+      <td>max_input_vars</td>
+      <td>3000</td>
+    </tr>
+    <tr>
+      <td>PHP_MEMORY_LIMIT</td>
+      <td>memory_limit</td>
+      <td>192M</td>
+    </tr>
+    <tr>
+      <td>PHP_UPLOAD_SIZE</td>
+      <td>upload_max_filesize</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_TIME</td>
+      <td>max_input_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_EXEC_TIME</td>
+      <td>max_execution_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_TIMEZONE</td>
+      <td>date.timezone</td>
+      <td>UTC</td>
+    </tr>
+    <tr>
+      <td>PHP_POST_SIZE</td>
+      <td>post_max_size</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_OPCACHE</td>
+      <td>opcache.enable</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>PHP_ERROR_REPORTING</td>
+      <td>error_reporting</td>
+      <td>E_ALL & ~E_DEPRECATED & ~E_STRICT</td>
+    </tr>
+    <tr>
+      <td>PHP_DISPLAY_ERRORS</td>
+      <td>display_errors</td>
+      <td>Off</td>
+    </tr>
+    <tr>
+      <td>PHP_LOG_ERRORS</td>
+      <td>log_errors</td>
+      <td>On</td>
+    </tr>
   </tbody>
 </table>
 

--- a/8.1-nginx/startup/60-php-config.sh
+++ b/8.1-nginx/startup/60-php-config.sh
@@ -3,6 +3,7 @@
 echo >&2 "Setting PHP tunables..."
 
 PHP_INI_PATH=/etc/php/8.1/fpm/
+PHP_INI_CONF_PATH=/etc/php/8.1/fpm/conf.d/
 
 sed -i 's/^;\? \?cgi.fix_pathinfo=.*/cgi.fix_pathinfo=0/g' ${PHP_INI_PATH}php.ini
 
@@ -46,4 +47,41 @@ if [ -z ${PHP_POST_SIZE} ]; then
   echo >&2 "PHP_POST_SIZE not set, skipping..."
 else
   sed -i "s/post_max_size = .*/post_max_size = $PHP_POST_SIZE/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_DISPLAY_ERRORS} ]; then
+  echo >&2 "PHP_DISPLAY_ERRORS not set, skipping..."
+else
+  sed -i "s/display_errors = .*/display_errors = $PHP_DISPLAY_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_ERROR_REPORTING} ]; then
+  echo >&2 "PHP_ERROR_REPORTING not set, skipping..."
+else
+  # first, verify if error_reporting string is valid
+  php -r "error_reporting($PHP_ERROR_REPORTING);" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo >&2 "PHP_ERROR_REPORTING is not valid, skipping..."
+  fi
+  sed -i "s/error_reporting = .*/error_reporting = $PHP_ERROR_REPORTING/g" "${PHP_INI_PATH}php.ini"
+fi
+
+# add opcache.enable bool
+if [ -z ${PHP_OPCACHE_ENABLE} ]; then
+  echo >&2 "PHP_OPCACHE_ENABLE not set, skipping..."
+else
+  echo >&2 "PHP_OPCACHE_ENABLE set, enabling..."
+  # if the line opcache.enable= exists, replace it, or else add it
+  if grep -q "opcache.enable=" "${PHP_INI_CONF_PATH}10-opcache.ini"; then
+    sed -i "s/opcache.enable=.*/opcache.enable=$PHP_OPCACHE_ENABLE/g" "${PHP_INI_CONF_PATH}10-opcache.ini"
+  else
+    echo "opcache.enable=$PHP_OPCACHE_ENABLE" >> "${PHP_INI_CONF_PATH}10-opcache.ini"
+  fi
+fi
+
+# add log_errors bool
+if [ -z ${PHP_LOG_ERRORS} ]; then
+  echo >&2 "PHP_LOG_ERRORS not set, skipping..."
+else
+  sed -i "s/log_errors=.*/log_errors=$PHP_LOG_ERRORS/g" "${PHP_INI_PATH}php.ini"
 fi

--- a/8.2-nginx/Dockerfile
+++ b/8.2-nginx/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex; \
       php8.2-protobuf \
       php8.2-xml \
       php8.2-xmlrpc \
+      php8.2-soap \
       php8.2-zip \
       php8.2-zstd \
       rcs \

--- a/8.2-nginx/README.md
+++ b/8.2-nginx/README.md
@@ -36,6 +36,66 @@
       <td>Postmark Message Stream ID</td>
       <td><pre>null</pre></td>
     </tr>
+         <tr>
+      <td>PHP_MAX_CONN</td>
+      <td>Maximum number of connections</td>
+      <td>35</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_VAR</td>
+      <td>max_input_vars</td>
+      <td>3000</td>
+    </tr>
+    <tr>
+      <td>PHP_MEMORY_LIMIT</td>
+      <td>memory_limit</td>
+      <td>192M</td>
+    </tr>
+    <tr>
+      <td>PHP_UPLOAD_SIZE</td>
+      <td>upload_max_filesize</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_INPUT_TIME</td>
+      <td>max_input_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_EXEC_TIME</td>
+      <td>max_execution_time</td>
+      <td>300</td>
+    </tr>
+    <tr>
+      <td>PHP_TIMEZONE</td>
+      <td>date.timezone</td>
+      <td>UTC</td>
+    </tr>
+    <tr>
+      <td>PHP_POST_SIZE</td>
+      <td>post_max_size</td>
+      <td>250M</td>
+    </tr>
+    <tr>
+      <td>PHP_OPCACHE</td>
+      <td>opcache.enable</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>PHP_ERROR_REPORTING</td>
+      <td>error_reporting</td>
+      <td>E_ALL & ~E_DEPRECATED & ~E_STRICT</td>
+    </tr>
+    <tr>
+      <td>PHP_DISPLAY_ERRORS</td>
+      <td>display_errors</td>
+      <td>Off</td>
+    </tr>
+    <tr>
+      <td>PHP_LOG_ERRORS</td>
+      <td>log_errors</td>
+      <td>On</td>
+    </tr>
   </tbody>
 </table>
 

--- a/8.2-nginx/startup/50-entrypoint.sh
+++ b/8.2-nginx/startup/50-entrypoint.sh
@@ -11,14 +11,6 @@ if ! [ "$(ls -A /var/www/html)" ]; then
   chown -R www-data:www-data /var/www
   echo >&2 "Complete! Sample files have been successfully copied to /var/www/"
 else
-  if [ ! -d /var/www/nginx ]; then
-    mkdir -p /var/www/nginx
-    chown -R www-data:www-data /var/www/nginx
-  fi
-  if [ ! -d /var/www/logs ]; then
-    mkdir -p /var/www/logs
-    chown -R www-data:www-data /var/www/logs
-  fi
   if [ -f /var/www/nginx/site.conf ]; then
     cp /var/www/nginx/site.conf /etc/nginx/sites-available/default
   fi

--- a/8.2-nginx/startup/50-entrypoint.sh
+++ b/8.2-nginx/startup/50-entrypoint.sh
@@ -11,6 +11,14 @@ if ! [ "$(ls -A /var/www/html)" ]; then
   chown -R www-data:www-data /var/www
   echo >&2 "Complete! Sample files have been successfully copied to /var/www/"
 else
+  if [ ! -d /var/www/nginx ]; then
+    mkdir -p /var/www/nginx
+    chown -R www-data:www-data /var/www/nginx
+  fi
+  if [ ! -d /var/www/logs ]; then
+    mkdir -p /var/www/logs
+    chown -R www-data:www-data /var/www/logs
+  fi
   if [ -f /var/www/nginx/site.conf ]; then
     cp /var/www/nginx/site.conf /etc/nginx/sites-available/default
   fi

--- a/8.2-nginx/startup/60-php-config.sh
+++ b/8.2-nginx/startup/60-php-config.sh
@@ -47,3 +47,40 @@ if [ -z ${PHP_POST_SIZE} ]; then
 else
   sed -i "s/post_max_size = .*/post_max_size = $PHP_POST_SIZE/g" "${PHP_INI_PATH}php.ini"
 fi
+
+if [ -z ${PHP_DISPLAY_ERRORS} ]; then
+  echo >&2 "PHP_DISPLAY_ERRORS not set, skipping..."
+else
+  sed -i "s/display_errors = .*/display_errors = $PHP_DISPLAY_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi
+
+if [ -z ${PHP_ERROR_REPORTING} ]; then
+  echo >&2 "PHP_ERROR_REPORTING not set, skipping..."
+else
+  # first, verify if error_reporting string is valid
+  php -r "error_reporting($PHP_ERROR_REPORTING);" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo >&2 "PHP_ERROR_REPORTING is not valid, skipping..."
+  fi
+  sed -i "s/error_reporting = .*/error_reporting = $PHP_ERROR_REPORTING/g" "${PHP_INI_PATH}php.ini"
+fi
+
+# add opcache.enable bool
+if [ -z ${PHP_OPCACHE_ENABLE} ]; then
+  echo >&2 "PHP_OPCACHE_ENABLE not set, skipping..."
+else
+  echo >&2 "PHP_OPCACHE_ENABLE set, enabling..."
+  # if the line opcache.enable= exists, replace it, or else add it
+  if grep -q "opcache.enable=" "${PHP_INI_CONF_PATH}10-opcache.ini"; then
+    sed -i "s/opcache.enable=.*/opcache.enable=$PHP_OPCACHE_ENABLE/g" "${PHP_INI_CONF_PATH}10-opcache.ini"
+  else
+    echo "opcache.enable=$PHP_OPCACHE_ENABLE" >> "${PHP_INI_CONF_PATH}10-opcache.ini"
+  fi
+fi
+
+# add log_errors bool
+if [ -z ${PHP_LOG_ERRORS} ]; then
+  echo >&2 "PHP_LOG_ERRORS not set, skipping..."
+else
+  sed -i "s/log_errors=.*/log_errors=$PHP_LOG_ERRORS/g" "${PHP_INI_PATH}php.ini"
+fi

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 If you encounter a technical issue, you may [open an issue](https://github.com/ComputeStacks/cs-docker-php/issues). However, for questions or how-to's, please [post on our forum](https://forum.computestacks.com).
 
 
+## Migrating from OpenLiteSpeed to nginx
+```
+  sed -i 's/\/usr\/local\/lsws\/lsphp.*\/bin\/php/\/usr\/bin\/php/g' /var/www/crontab
+```
+
+
 ## Contributing
 
 Contributions are welcome! Before you submit a pull request, feel free to [post on our forum](https://forum.computestacks.com) your idea and we can have a discussion.


### PR DESCRIPTION
I added some more options to the tuneable PHP settings using environmental variables;

- Toggle opcache; for some sites, opcache causes strange issues. This adds the ability to disable opcode to allow for debugging
- Error logging; tweak how PHP handles error logging, like display errors, log errors and error reporting level